### PR TITLE
Inject klass name in file

### DIFF
--- a/lib/fixture_record/data.rb
+++ b/lib/fixture_record/data.rb
@@ -9,14 +9,16 @@ class FixtureRecord::Data < Hash
     if File.exist?(fixture_path_for(klass))
       YAML.load_file(fixture_path_for(klass))
     else
-      {}
+      {'_fixture' => {'model_class' => klass.name}}
     end
   end
 
   def write!
     FileUtils.mkdir_p(FixtureRecord.base_path)
     self.each do |klass, data|
-      File.open(fixture_path_for(klass), 'w') { |f| f.write data.to_yaml }
+      File.open(fixture_path_for(klass), 'w') do |f|
+        f.write data.to_yaml
+      end
     end
   end
 

--- a/test/belongs_to_updation_test.rb
+++ b/test/belongs_to_updation_test.rb
@@ -6,7 +6,7 @@ class BelongsToUpdation < ActiveSupport::TestCase
     with_fixture_file_reset(User, Post) do
       user.to_fixture_record(:posts)
       post_fixtures = yml_contents_for(Post)
-      assert_includes post_fixtures.values.first.keys, 'author'
+      assert_includes post_fixtures.values.second.keys, 'author'
     end
   end
 end

--- a/test/fixture_record_test.rb
+++ b/test/fixture_record_test.rb
@@ -11,6 +11,7 @@ class FixtureRecordTest < ActiveSupport::TestCase
       refute yml_contents_for(User).key? user.test_fixture_name
       user.to_fixture_record
       assert yml_contents_for(User).key? user.test_fixture_name
+      assert yml_contents_for(User).key? '_fixture'
     end
   end
 

--- a/test/through_association_test.rb
+++ b/test/through_association_test.rb
@@ -5,9 +5,9 @@ class ThroughAssociationTest < ActiveSupport::TestCase
     user = users(:user_one)
     with_fixture_file_reset(User, Post, Comment) do
       user.to_fixture_record(:commenting_users)
-      assert_equal 2, yml_contents_for(User).length
-      assert_equal 2, yml_contents_for(Post).length
-      assert_equal 1, yml_contents_for(Comment).length
+      assert_equal 3, yml_contents_for(User).length
+      assert_equal 3, yml_contents_for(Post).length
+      assert_equal 2, yml_contents_for(Comment).length
     end
   end
 

--- a/test/traversal_test.rb
+++ b/test/traversal_test.rb
@@ -7,7 +7,7 @@ class TraversalTest < ActiveSupport::TestCase
       refute File.exist? fixture_path_for(Post)
       user.to_fixture_record(:posts)
       assert File.exist? fixture_path_for(Post)
-      assert_equal 2, yml_contents_for(Post).length
+      assert_equal 3, yml_contents_for(Post).length
     end
   end
 
@@ -15,9 +15,9 @@ class TraversalTest < ActiveSupport::TestCase
     user = users(:user_one)
     with_fixture_file_reset(User, Post, Comment) do
       user.to_fixture_record(posts: [comments: :user])
-      assert_equal 2, yml_contents_for(User).length
-      assert_equal 2, yml_contents_for(Post).length
-      assert_equal 1, yml_contents_for(Comment).length
+      assert_equal 3, yml_contents_for(User).length
+      assert_equal 3, yml_contents_for(Post).length
+      assert_equal 2, yml_contents_for(Comment).length
     end
   end
 
@@ -25,9 +25,9 @@ class TraversalTest < ActiveSupport::TestCase
     post = posts(:post_1)
     with_fixture_file_reset(User, Post, Comment) do
       post.to_fixture_record(:author, comments: :user)
-      assert_equal 2, yml_contents_for(User).length
-      assert_equal 1, yml_contents_for(Post).length
-      assert_equal 1, yml_contents_for(Comment).length
+      assert_equal 3, yml_contents_for(User).length
+      assert_equal 2, yml_contents_for(Post).length
+      assert_equal 2, yml_contents_for(Comment).length
     end
   end
 end


### PR DESCRIPTION
Namespaced classes can be problematic if when loading yaml files. The convention is that the class matches the filename which can be problematic for namespaced classes. To support this, Rails allows for the model_class to be declared in the `_fixture` object.